### PR TITLE
build(ci): added release job to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,3 +203,31 @@ jobs:
           readme_file: "README.md"      
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+  release:    
+    needs: [docker-sfnb,docker-sysprint]    
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest    
+    permissions:
+      contents: write      
+    steps:      
+      - name: Checkout
+        uses: actions/checkout@v2                 
+      - name: Get version from tag
+        id: tag_name
+        shell: bash
+        run: |          
+          GHREF=${GITHUB_REF#refs/tags/}; echo ::set-output name=current_version::${GHREF%-*}           
+          echo ::set-output name=current_tag::${GITHUB_REF#refs/tags/}                       
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:          
+          version: ${{ steps.tag_name.outputs.current_version }}
+          path: ./CHANGELOG.md      
+      - name: Release
+        uses: softprops/action-gh-release@v1        
+        with:
+          body: ${{ steps.changelog_reader.outputs.changes }}          
+          token: ${{ secrets.GITHUB_TOKEN }}          
+          prerelease: contains(steps.tag_name.outputs.current_version, '-rc')
+          draft: true


### PR DESCRIPTION
Add release job to CI workflow. 

Signed-off-by: Frederico Araujo <frederico.araujo@ibm.com>